### PR TITLE
Remove obsolete LICENSE note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ This project uses GitHub Actions for continuous integration and deployment. Work
 
 ## Licensing
 
-This project is licensed under the MIT License. See the `LICENSE` file for details. (Note: `LICENSE` file will be added in a future phase.)
+This project is licensed under the MIT License. See the `LICENSE` file for details.
 
 


### PR DESCRIPTION
## Summary
- clean up README licensing note since LICENSE is present

## Testing
- `pnpm run lint` *(fails: setAgentStatus unused, __dirname not defined)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6883e90b4db0833283f6139e8f8c5dd3