### PR TITLE
Fix Flask remnants in backend user API

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from src.logging_config import agent_logger
 from src.websocket_manager import messenger
+from src.routes.user import router as user_router
 
 app = FastAPI(title="Self-Building Site API", version="1.0.0")
 
@@ -28,6 +29,9 @@ app.add_middleware(
 static_folder_path = os.path.join(os.path.dirname(__file__), 'static')
 if os.path.exists(static_folder_path):
     app.mount("/static", StaticFiles(directory=static_folder_path), name="static")
+
+# API routes
+app.include_router(user_router, prefix="/api")
 
 @app.on_event("startup")
 async def startup_event():

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -1,18 +1,54 @@
-from flask_sqlalchemy import SQLAlchemy
+"""User models used by the API."""
 
-db = SQLAlchemy()
+from __future__ import annotations
 
-class User(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(80), unique=True, nullable=False)
-    email = db.Column(db.String(120), unique=True, nullable=False)
+from pydantic import BaseModel
+from typing import List, Optional
+from uuid import uuid4
 
-    def __repr__(self):
-        return f'<User {self.username}>'
 
-    def to_dict(self):
-        return {
-            'id': self.id,
-            'username': self.username,
-            'email': self.email
-        }
+class User(BaseModel):
+    """Simple user model."""
+
+    id: str
+    username: str
+    email: str
+
+
+# In-memory store for users. This keeps the example lightweight and removes the
+# dependency on Flask's SQLAlchemy extension which wasn't included in the
+# project dependencies.
+_USERS: List[User] = []
+
+
+def get_users() -> List[User]:
+    return list(_USERS)
+
+
+def create_user(username: str, email: str) -> User:
+    user = User(id=str(uuid4()), username=username, email=email)
+    _USERS.append(user)
+    return user
+
+
+def get_user(user_id: str) -> Optional[User]:
+    return next((u for u in _USERS if u.id == user_id), None)
+
+
+def update_user(user_id: str, username: Optional[str], email: Optional[str]) -> Optional[User]:
+    user = get_user(user_id)
+    if user is None:
+        return None
+    if username is not None:
+        user.username = username
+    if email is not None:
+        user.email = email
+    return user
+
+
+def delete_user(user_id: str) -> bool:
+    user = get_user(user_id)
+    if user is None:
+        return False
+    _USERS.remove(user)
+    return True


### PR DESCRIPTION
## Summary
- reimplement user model using Pydantic and an in-memory store
- rewrite user routes using FastAPI's `APIRouter`
- include the new router in the main FastAPI app

## Testing
- `ruff check src/models/user.py src/routes/user.py src/main.py | head -n 20`
- `python -m uvicorn src.main:app --port 8000 --log-level warning` *(started then killed)*

------
https://chatgpt.com/codex/tasks/task_e_6883e763cee483329b06afc0ba76305b